### PR TITLE
Fix turbofish using late bound lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "func_wrap"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 

--- a/downstream/user.rs
+++ b/downstream/user.rs
@@ -16,6 +16,9 @@ const _: () = {
     #[attr]
     fn baz<T>()
     {}
+
+    fn with_lifetime<'explicit>()
+    {}
 };
 
 const _: () = {
@@ -28,6 +31,9 @@ const _: () = {
         {
             println!("foo")
         }
+
+        fn with_lifetime<'explicit>()
+        {}
     }
 
     #[attr]
@@ -39,6 +45,9 @@ const _: () = {
         {
             println!("foo")
         }
+
+        fn with_lifetime<'explicit>()
+        {}
     }
 };
 
@@ -54,5 +63,8 @@ const _: () = {
         {
             println!("foo")
         }
+
+        fn with_lifetime<'explicit>()
+        {}
     }
 };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -87,7 +87,7 @@ fn simple_fn ()
                     println!("foo")
                 }
 
-                foo
+                foo ::<>
             })(arg_0, second, arg_2, arg_3)
         }
     });
@@ -132,7 +132,7 @@ fn default_method ()
                         () : Copy,
                     {}
 
-                    <Self as __FuncWrap<T>>::foo
+                    <Self as __FuncWrap<T>>::foo ::<>
                 })(self, second, arg_2, arg_3)
             }
         }
@@ -184,7 +184,7 @@ mod impls {
                             }
                         }
 
-                        <Self as __FuncWrap<T>>::foo
+                        <Self as __FuncWrap<T>>::foo ::<>
                     })(self, second, arg_2, arg_3)
                 }
             }
@@ -233,7 +233,7 @@ mod impls {
                             }
                         }
 
-                        <Self as __FuncWrap<T, U>>::foo
+                        <Self as __FuncWrap<T, U>>::foo ::<>
                     })(self, second, arg_2, arg_3)
                 }
             }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -88,7 +88,7 @@ fn simple_fn ()
                     println!("foo")
                 }
 
-                foo
+                foo ::<>
             })(arg_0, second, arg_2, arg_3)
         }
     });
@@ -161,7 +161,7 @@ fn default_method ()
                         () : Copy,
                     {}
 
-                    <Self as __FuncWrap<T>>::foo
+                    <Self as __FuncWrap<T>>::foo ::<>
                 })(self, second, arg_2, arg_3)
             }
         }
@@ -241,7 +241,7 @@ mod impls {
                             }
                         }
 
-                        <Self as __FuncWrap<T>>::foo
+                        <Self as __FuncWrap<T>>::foo ::<>
                     })(self, second, arg_2, arg_3)
                 }
             }
@@ -290,7 +290,7 @@ mod impls {
                             }
                         }
 
-                        <Self as __FuncWrap<T, U>>::foo
+                        <Self as __FuncWrap<T, U>>::foo ::<>
                     })(self, second, arg_2, arg_3)
                 }
             }


### PR DESCRIPTION
`::syn`'s `.as_turbofish()` convenience method yields a `ToTokens`able that emits the lifetime parameters present in the `Generics`, which makes it unusable on function call position, since that hits the late-bound lifetimes issue.
For the moment, circumvent the issue by manually hand-rolling the implementation of a function-friendly turbofish, while waiting for `::syn` to feature a `.as_function_turbofish()` convenience helper or something along those lines (cc @dtolnay)